### PR TITLE
Update __init__.py to allow ignore options

### DIFF
--- a/src/litestar_browser_reload/__init__.py
+++ b/src/litestar_browser_reload/__init__.py
@@ -1,41 +1,36 @@
 # SPDX-FileCopyrightText: 2024-present Tobi DEGNON <tobidegnon@proton.me>
 #
 # SPDX-License-Identifier: MIT
-from __future__ import annotations
-
 import asyncio
 import logging
 import uuid
 from pathlib import Path
 from typing import Sequence
-from typing import TYPE_CHECKING
-
+from typing import Union
+from litestar import WebSocket
+from litestar.config.app import AppConfig
 from litestar.handlers import WebsocketListener
 from litestar.plugins import InitPluginProtocol
 from litestar.static_files import create_static_files_router
 from watchfiles import awatch
 from watchfiles import DefaultFilter
 
-if TYPE_CHECKING:
-    from litestar import WebSocket
-    from litestar.config.app import AppConfig
-
 logger = logging.getLogger("browser-reload")
-
 version_id = str(uuid.uuid4())
 
-
 def reload_endpoint(
-    watch_paths: Sequence[Path | str],
-    ignore_dirs: Sequence[str] | None = None,
-    ignore_entity_patterns: Sequence[str] | None = None,
+        watch_paths: Sequence[Union[Path, str]],
+        ignore_dirs: Sequence[str] | None = None,
+        ignore_entity_patterns: Sequence[str] | None = None,
 ):
     # shamelessy copied from https://github.com/samuelcolvin/foxglove/blob/main/foxglove/devtools.py
-
     async def watch_reload(prompt_reload):
         async for _ in awatch(
-            *watch_paths,
-            watch_filter=DefaultFilter(ignore_dirs=ignore_dirs, ignore_entity_patterns=ignore_entity_patterns),
+                *watch_paths,
+                watch_filter=DefaultFilter(
+                    ignore_dirs=ignore_dirs,
+                    ignore_entity_patterns=ignore_entity_patterns
+                ),
         ):
             await prompt_reload()
 
@@ -66,14 +61,34 @@ def reload_endpoint(
 
     return BrowserReloadHandler
 
-
 class BrowserReloadPlugin(InitPluginProtocol):
-    def __init__(self, watch_paths: Sequence[Path | str]) -> None:
+    def __init__(
+        self, 
+        watch_paths: Sequence[Union[Path, str]],
+        ignore_dirs: Sequence[str] | None = None,
+        ignore_entity_patterns: Sequence[str] | None = (
+            r'\.py[cod]$',
+            r'\.___jb_...___$',
+            r'\.sw.$',
+            r'~$',
+            r'^\.\#',
+            r'^\.DS_Store$',
+            r'^flycheck_'
+        ),
+    ) -> None:
         self.watch_paths = watch_paths
+        self.ignore_dirs = ignore_dirs
+        self.ignore_entity_patterns = ignore_entity_patterns
 
     def on_app_init(self, app_config: AppConfig) -> AppConfig:
         if app_config.debug:
-            app_config.route_handlers.append(reload_endpoint(self.watch_paths))
+            app_config.route_handlers.append(
+                reload_endpoint(
+                    self.watch_paths,
+                    ignore_dirs=self.ignore_dirs,
+                    ignore_entity_patterns=self.ignore_entity_patterns
+                )
+            )
             app_config.route_handlers.append(
                 create_static_files_router(
                     directories=[Path(__file__).parent / "static"],

--- a/src/litestar_browser_reload/__init__.py
+++ b/src/litestar_browser_reload/__init__.py
@@ -29,13 +29,18 @@ def reload_endpoint(
     watch_paths: Sequence[Path | str],
     ignore_dirs: Sequence[str] | None = None,
     ignore_entity_patterns: Sequence[str] | None = None,
+    watch_filter: DefaultFilter | None = None,
 ):
     # shamelessy copied from https://github.com/samuelcolvin/foxglove/blob/main/foxglove/devtools.py
 
     async def watch_reload(prompt_reload):
+        filter_class = watch_filter or DefaultFilter(
+            ignore_dirs=ignore_dirs,
+            ignore_entity_patterns=ignore_entity_patterns,
+        )
         async for _ in awatch(
             *watch_paths,
-            watch_filter=DefaultFilter(ignore_dirs=ignore_dirs, ignore_entity_patterns=ignore_entity_patterns),
+            watch_filter=filter_class,
         ):
             await prompt_reload()
 
@@ -70,25 +75,24 @@ def reload_endpoint(
 class BrowserReloadPlugin(InitPluginProtocol):
     def __init__(
         self,
-        watch_paths: Sequence[Path | str],
+        watch_paths: Sequence[Path | str] = [],
         ignore_dirs: Sequence[str] | None = None,
-        ignore_entity_patterns: Sequence[str] | None = (
-            r'\.py[cod]$',
-            r'\.___jb_...___$',
-            r'\.sw.$',
-            r'~$',
-            r'^\.\#',
-            r'^\.DS_Store$',
-            r'^flycheck_'
-        ),
+        ignore_entity_patterns: Sequence[str] | None = None,
+        watch_filter: DefaultFilter | None = None,
     ) -> None:
         self.watch_paths = watch_paths
         self.ignore_dirs = ignore_dirs
         self.ignore_entity_patterns = ignore_entity_patterns
+        self.watch_filter = watch_filter
 
     def on_app_init(self, app_config: AppConfig) -> AppConfig:
         if app_config.debug:
-            app_config.route_handlers.append(reload_endpoint(self.watch_paths))
+            app_config.route_handlers.append(reload_endpoint(
+                self.watch_paths,
+                ignore_dirs=self.ignore_dirs,
+                ignore_entity_patterns=self.ignore_entity_patterns,
+                watch_filter=self.watch_filter,
+            ))
             app_config.route_handlers.append(
                 create_static_files_router(
                     directories=[Path(__file__).parent / "static"],

--- a/src/litestar_browser_reload/__init__.py
+++ b/src/litestar_browser_reload/__init__.py
@@ -1,36 +1,41 @@
 # SPDX-FileCopyrightText: 2024-present Tobi DEGNON <tobidegnon@proton.me>
 #
 # SPDX-License-Identifier: MIT
+from __future__ import annotations
+
 import asyncio
 import logging
 import uuid
 from pathlib import Path
 from typing import Sequence
-from typing import Union
-from litestar import WebSocket
-from litestar.config.app import AppConfig
+from typing import TYPE_CHECKING
+
 from litestar.handlers import WebsocketListener
 from litestar.plugins import InitPluginProtocol
 from litestar.static_files import create_static_files_router
 from watchfiles import awatch
 from watchfiles import DefaultFilter
 
+if TYPE_CHECKING:
+    from litestar import WebSocket
+    from litestar.config.app import AppConfig
+
 logger = logging.getLogger("browser-reload")
+
 version_id = str(uuid.uuid4())
 
+
 def reload_endpoint(
-        watch_paths: Sequence[Union[Path, str]],
-        ignore_dirs: Sequence[str] | None = None,
-        ignore_entity_patterns: Sequence[str] | None = None,
+    watch_paths: Sequence[Path | str],
+    ignore_dirs: Sequence[str] | None = None,
+    ignore_entity_patterns: Sequence[str] | None = None,
 ):
     # shamelessy copied from https://github.com/samuelcolvin/foxglove/blob/main/foxglove/devtools.py
+
     async def watch_reload(prompt_reload):
         async for _ in awatch(
-                *watch_paths,
-                watch_filter=DefaultFilter(
-                    ignore_dirs=ignore_dirs,
-                    ignore_entity_patterns=ignore_entity_patterns
-                ),
+            *watch_paths,
+            watch_filter=DefaultFilter(ignore_dirs=ignore_dirs, ignore_entity_patterns=ignore_entity_patterns),
         ):
             await prompt_reload()
 
@@ -61,10 +66,11 @@ def reload_endpoint(
 
     return BrowserReloadHandler
 
+
 class BrowserReloadPlugin(InitPluginProtocol):
     def __init__(
-        self, 
-        watch_paths: Sequence[Union[Path, str]],
+        self,
+        watch_paths: Sequence[Path | str],
         ignore_dirs: Sequence[str] | None = None,
         ignore_entity_patterns: Sequence[str] | None = (
             r'\.py[cod]$',
@@ -82,13 +88,7 @@ class BrowserReloadPlugin(InitPluginProtocol):
 
     def on_app_init(self, app_config: AppConfig) -> AppConfig:
         if app_config.debug:
-            app_config.route_handlers.append(
-                reload_endpoint(
-                    self.watch_paths,
-                    ignore_dirs=self.ignore_dirs,
-                    ignore_entity_patterns=self.ignore_entity_patterns
-                )
-            )
+            app_config.route_handlers.append(reload_endpoint(self.watch_paths))
             app_config.route_handlers.append(
                 create_static_files_router(
                     directories=[Path(__file__).parent / "static"],


### PR DESCRIPTION
This adds the ability to pass in `ignore_dirs`, or `ignore_entity_patterns` as options. It also sets the default so it ignores .py files by default as it will auto reload already if --reload is set.